### PR TITLE
enable to place js tag wherever after jquery/modernizr

### DIFF
--- a/bootstrap-datepicker-mobile.js
+++ b/bootstrap-datepicker-mobile.js
@@ -68,6 +68,8 @@
 
   $(window).on('resize.bootstrapDatepickerMobile', bootstrapDatepickerMobile);
 
-  bootstrapDatepickerMobile();
+  $(function() {
+    bootstrapDatepickerMobile();
+  });
 
 }(jQuery, Modernizr, window));


### PR DESCRIPTION
## Background
I'm developing web service with rails4.
Rails locate javascript loading tag in <head> tag.

## Problem

So, I would like to place javascript loading tag in <head>.
But bootstrapDatepickerMobile method called immediately after loaded.


## Solution

So, I wrapped the method with $(function() {});.